### PR TITLE
Revert "fix: image order"

### DIFF
--- a/src/content_script/System/TwitterCrawler.ts
+++ b/src/content_script/System/TwitterCrawler.ts
@@ -44,10 +44,6 @@ const getTweetImages: () => Promise<Attachment[]> = async () => {
     res.push({ blob: blob, isSensitive: isFlagged })
   }
 
-  if (res.length === 4) {
-    [res[1], res[2]] = [res[2], res[1]]
-  }
-
   return res;
 }
 


### PR DESCRIPTION
Reverts suila-ai/Misstter#1

画像欄の並びが変更されたため